### PR TITLE
Correctly use MAKEFLAGS to allow setting the amount of jobs for make

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ The patches need to have the extension `.patch`
   For example `DEFCONFIG=my_defconfig` with `my_defconfig` being available at `arch/arm/configs/my_defconfig`'
   - To configure using `all*config` set `ALLCONFIG` to one of the allconfig options `allyesconfig`, `allmodconfig`, `allnoconfig` or `randconfig`.
   To override which config is used as the starting point set [`KCONFIG_ALLCONFIG`](https://github.com/raspberrypi/linux/blob/560909d433109e3da08757237f30576c71697914/Documentation/kbuild/kconfig.txt#L51) to the path of the config file. For example `ALLCONFIG=/workdir/configs/myminimalconfig`
+- The amount of jobs used by make will default to the value returned by `nproc`.
+  To override this set the `MAKEFLAGS` environment variable. For example `MAKEFLAGS=-j8`.
 
 ### Example usage
 ```
 # Checkout kernel sources
-$ git clone --single-branch --branch rpi-4.9.y --depth 1 https://www.github.com/raspberrypi/linux
+$ git clone --single-branch --branch rpi-4.14.y --depth 1 https://www.github.com/raspberrypi/linux
 
 # Build a kernel archive using the docker image
 # using a volume mount for the linux sources to /workdir

--- a/build-rpi3-kernel
+++ b/build-rpi3-kernel
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 set -x -e
 
-export CONCURRENCY_LEVEL=${CONCURRENCY_LEVEL:=4}
 export LINUX_SRC_DIR=${LINUX_SRC_DIR:-${WORKDIR}/linux}
+
+# Use -j<nproc> as default if MAKEFLAGS is not set
+if [[ -v "${MAKEFLAGS}" ]]; then
+  export MAKEFLAGS="-j$(nproc)"
+fi
 
 # Start building the kernel
 patch_dir_array=( $PATCH_DIRS )

--- a/build-rpi3-kernel
+++ b/build-rpi3-kernel
@@ -9,7 +9,7 @@ if [[ -v "${MAKEFLAGS}" ]]; then
 fi
 
 # Start building the kernel
-patch_dir_array=( $PATCH_DIRS )
+patch_dir_array=( "${PATCH_DIRS}" )
 
 for patch_dir in "${patch_dir_array[@]}"
 do
@@ -24,7 +24,7 @@ do
 done
 
 # Configure kernel
-if [[ -v ALLCONFIG ]]; then
+if [[ -v "${ALLCONFIG}" ]]; then
   make KCONFIG_ALLCONFIG="${KCONFIG_ALLCONFIG:-arch/arm/configs/bcm2709_defconfig}" ${ALLCONFIG}
 else
   make "${DEFCONFIG:-bcm2709_defconfig}"


### PR DESCRIPTION
If not set MAKEFLAGS defaults to the return value of 'nproc'.

Validated locally, all my cores are used now whereas before only 1 was used.