### PR TITLE
Add linux 4.19.y build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,13 @@ FROM debian:jessie
 # Install build dependencies
 RUN apt-get update && apt-get install -y \
   bc \
+  bison \
   build-essential \
   curl \
+  flex \
   git-core \
   libncurses5-dev \
+  libssl-dev \
   module-init-tools
 
 # Install crosscompile toolchain for ARM64/aarch64


### PR DESCRIPTION
Adds dependencies to container image required to build norns-4.19.y and norns-4.19.y-rt branches.